### PR TITLE
revert: remove workflow_dispatch CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 ---
 name: CI
 on:
-  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/update-untitled-icons.yml
+++ b/.github/workflows/update-untitled-icons.yml
@@ -11,7 +11,6 @@ on:
     - cron: '0 9 * * 1' # Weekly on Mondays at 9am UTC
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -76,5 +75,3 @@ jobs:
           EOF
           )" \
             --base main
-
-          gh workflow run ci.yml --ref "$BRANCH"


### PR DESCRIPTION
## Summary

Reverts the `workflow_dispatch` approach for triggering CI on automated icon update PRs.

**What was tried:** Adding `workflow_dispatch` to `ci.yml` and calling `gh workflow run ci.yml --ref $BRANCH` after PR creation.

**Why it doesn't work:** While the CI run executes successfully and the check run is associated with the correct SHA, GitHub does not include `workflow_dispatch`-triggered check suites in the PR's `statusCheckRollup`. The checks run but don't appear on the PR.
