### PR TITLE
feat: add link to untitledui.com for browsing icons by category

### DIFF
--- a/stories/icons.css
+++ b/stories/icons.css
@@ -27,6 +27,22 @@
 	border-color: var(--cz-color-border-brand);
 }
 
+.icon-gallery-note {
+	font-size: var(--cz-text-sm);
+	line-height: var(--cz-text-sm-line-height);
+	color: var(--cz-color-text-tertiary);
+	padding: calc(var(--cz-spacing) * 2) 0 0;
+}
+
+.icon-gallery-note a {
+	color: var(--cz-color-text-brand);
+	text-decoration: none;
+}
+
+.icon-gallery-note a:hover {
+	text-decoration: underline;
+}
+
 .icon-gallery-count {
 	font-size: var(--cz-text-sm);
 	line-height: var(--cz-text-sm-line-height);

--- a/stories/untitled-icons.stories.ts
+++ b/stories/untitled-icons.stories.ts
@@ -17,6 +17,10 @@ export const Icons = () => html`
 			placeholder="Search icons..."
 			@input=${filterIcons}
 		/>
+		<div class="icon-gallery-note">
+			Browse icons by category on
+			<a href="https://untitledui.com/free-icons" target="_blank" rel="noopener">untitledui.com</a>
+		</div>
 		<div class="icon-gallery-count">${entries.length} icons</div>
 		<div class="icon-gallery-grid" @click=${copyImport('@neovici/cosmoz-icons/untitled')}>
 			${entries.map(


### PR DESCRIPTION
## Summary

- Add a note in the Untitled UI Icons Storybook page linking to [untitledui.com/free-icons](https://untitledui.com/free-icons)
- Users can browse icons by category (General, Arrows, Charts, Users, Communication, Layout, etc.) on the official site

The Untitled UI website organizes 1,100+ icons into 19 semantic categories with search tags, which is useful for discovering icons by purpose rather than name.

NEO-885