### PR TITLE
ci: use neovact app token in update-icons workflow to trigger CI

### DIFF
--- a/.github/workflows/update-untitled-icons.yml
+++ b/.github/workflows/update-untitled-icons.yml
@@ -18,8 +18,17 @@ jobs:
   update-icons:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.NEOVACT_APP_ID }}
+          private-key: ${{ secrets.NEOVACT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -45,7 +54,7 @@ jobs:
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Use the **neovact** GitHub App (`actions/create-github-app-token@v2`) to generate an installation token in `update-untitled-icons.yml`
- Pass the app token to checkout (so `git push` uses it) and to `GH_TOKEN` (so `gh pr create` uses it)
- This replaces `secrets.GITHUB_TOKEN`, which GitHub suppresses downstream workflow triggers for (CI, preview, automerge)

## Prerequisites

The org-level secrets `NEOVACT_APP_ID` and `NEOVACT_PRIVATE_KEY` must be available to this repo (they are already used by `cosmoz-frontend`).

## Security

Safe — `update-untitled-icons.yml` only triggers on `workflow_dispatch` and `schedule`, never on `pull_request` from forks.

Fixes NEO-890