### PR TITLE
chore: bump playwright to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@neovici/cfg": "^2.8.0",
         "@neovici/cosmoz-tokens": "^3.2.1",
         "@open-wc/testing": "^4.0.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "1.60.0",
         "@storybook/web-components-vite": "^10.0.3",
         "@types/mocha": "^10.0.6",
         "@types/node": "^25.0.2",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^16.2.7",
     "storybook": "^10.0.3",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "1.60.0",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
Pin `@playwright/test` to exact version `1.60.0` to avoid browser version mismatches when running `@vitest/browser-playwright`.\n\nRelates to FE-879